### PR TITLE
Update markers on timeline change

### DIFF
--- a/src/plugin.svelte
+++ b/src/plugin.svelte
@@ -67,6 +67,7 @@ onDestroy(() => {
 	Object.values(names).forEach(removeMarker);
 	broadcast.off('redrawFinished', redraw);
 	map.off('moveend', redraw);
+	store.off('timestamp', redraw);
 });
 
 // Same as https://pg.vrana.cz/mapa/ from here.
@@ -148,6 +149,7 @@ function init() {
 	document.head.appendChild(style);
 	broadcast.on('redrawFinished', redraw);
 	map.on('moveend', redraw);
+	store.on('timestamp', redraw);
 	if (Object.keys(sites).length) {
 		// Opening already loaded layer.
 		return;


### PR DESCRIPTION
Listen to store 'timestamp' changes so wind icons and indicators redraw when user moves Windy's timeline slider on PC (already working on phone). 

Previously only 'redrawFinished' and 'moveend' were handled, leaving markers stale on time selection changes.


https://github.com/user-attachments/assets/476cf5ac-89b6-406b-b490-b77cc0fd8762

